### PR TITLE
Listener sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Log bytes downloaded by a CloudFront CDN
 
 # Description
 
-This edge lambda is intended to sit behind a CloudFront distribution, executing on every [viewer response](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-cloudfront-trigger-events.html).  If the request was a successful Dovetail-type request (containing a `?reqid=1234`), the number and location of bytes actually sent to the client will be logged to CloudWatch.
+This edge lambda is intended to sit behind a CloudFront distribution, executing on every [viewer response](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-cloudfront-trigger-events.html).  If the request was a successful Dovetail-type request (containing a listener session `?ls=1234`), the number and location of bytes actually sent to the client will be logged to CloudWatch.
 
 The logged data has the following JSON format:
 
 ```json
-GET https://my.cloudfront.cdn/1234/the-digest/filename.mp3?reqid=the-reqid
+GET https://my.cloudfront.cdn/1234/the-digest/filename.mp3?ls=the-listener-session
 {
-  "uuid": "the-reqid",
+  "ls": "the-listener-session",
   "start":0,
   "end":10,
   "total":316645,

--- a/index.js
+++ b/index.js
@@ -40,7 +40,6 @@ function findListenerSession(str) {
   if (id) {
     return id
   } else {
-    console.warn(`[WARN] No listener session present: ${str}`)
     return null
   }
 }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ exports.handler = (event, context, callback) => {
     const region = (arn || '').replace(/^arn:aws:lambda:/, '').replace(/:.+$/, '')
     const method = request.method
     const status = parseInt(response.status, 10)
-    const uuid = findRequestId(request.querystring)
+    const session = findListenerSession(request.querystring)
     const digest = findDigest(request.uri)
     const length = findContentLength(response.headers)
 
@@ -23,8 +23,8 @@ exports.handler = (event, context, callback) => {
       const total = findRangeTotal(range, length)
       const rangeStart = findRangeStart(range)
       const rangeEnd = findRangeEnd(range, rangeStart, length)
-      if (method === 'GET' && status >= 200 && status < 300 && length > 0 && uuid) {
-        const data = {uuid: uuid, start: rangeStart, end: rangeEnd, total: total, digest: digest, region: region}
+      if (method === 'GET' && status >= 200 && status < 300 && length > 0 && session) {
+        const data = {ls: session, start: rangeStart, end: rangeEnd, total: total, digest: digest, region: region}
         const json = JSON.stringify(data)
         console.info(json)
       }
@@ -34,13 +34,13 @@ exports.handler = (event, context, callback) => {
   }
   callback(null, response)
 }
-function findRequestId(str) {
-  const param = (str || '').split('&').find(s => s.startsWith('reqid='))
-  const id = (param || '').replace(/^reqid=/, '')
+function findListenerSession(str) {
+  const param = (str || '').split('&').find(s => s.startsWith('ls='))
+  const id = (param || '').replace(/^ls=/, '')
   if (id) {
     return id
   } else {
-    console.warn(`[WARN] No reqid present: ${str}`)
+    console.warn(`[WARN] No listener session present: ${str}`)
     return null
   }
 }

--- a/index.test.js
+++ b/index.test.js
@@ -90,13 +90,11 @@ describe('handler', () => {
     REQUEST.querystring = 'foo=bar&ls='
     await exec()
     expect(console.info).toHaveBeenCalledTimes(0)
-    expect(console.warn).toHaveBeenCalledTimes(1)
-    expect(getMessage('warn', 0)).toEqual('[WARN] No listener session present: foo=bar&ls=')
+    expect(console.warn).toHaveBeenCalledTimes(0)
     delete REQUEST.querystring
     await exec()
     expect(console.info).toHaveBeenCalledTimes(0)
-    expect(console.warn).toHaveBeenCalledTimes(2)
-    expect(getMessage('warn', 1)).toEqual('[WARN] No listener session present: undefined')
+    expect(console.warn).toHaveBeenCalledTimes(0)
   })
 
   it('only logs valid content-range', async () => {

--- a/index.test.js
+++ b/index.test.js
@@ -86,7 +86,7 @@ describe('handler', () => {
     expect(console.info).toHaveBeenCalledTimes(0)
   })
 
-  it('only logs reqid bytes', async () => {
+  it('only logs listener-session bytes', async () => {
     REQUEST.querystring = 'foo=bar&ls='
     await exec()
     expect(console.info).toHaveBeenCalledTimes(0)

--- a/index.test.js
+++ b/index.test.js
@@ -21,7 +21,7 @@ describe('handler', () => {
 
   let REQUEST, RESPONSE
   beforeEach(() => {
-    REQUEST = {method: 'GET', querystring: 'reqid=1234abcd', uri: '/the_program_id/the_digest/the_filename.mp3'}
+    REQUEST = {method: 'GET', querystring: 'ls=1234abcd', uri: '/the_program_id/the_digest/the_filename.mp3'}
     RESPONSE = {status: '200', headers: {'content-length': [{value: '987654321'}], 'content-range': [{value: 'bytes 99-999/987654321'}]}}
   })
 
@@ -30,7 +30,7 @@ describe('handler', () => {
     await exec()
     expect(console.info).toHaveBeenCalledTimes(1)
     expect(getJSON('info', 0)).toMatchObject({
-      uuid: '1234abcd',
+      ls: '1234abcd',
       start: 0,
       end: 987654320,
       total: 987654321,
@@ -43,7 +43,7 @@ describe('handler', () => {
     await exec()
     expect(console.info).toHaveBeenCalledTimes(1)
     expect(getJSON('info', 0)).toMatchObject({
-      uuid: '1234abcd',
+      ls: '1234abcd',
       start: 99,
       end: 999,
       total: 987654321,
@@ -87,16 +87,16 @@ describe('handler', () => {
   })
 
   it('only logs reqid bytes', async () => {
-    REQUEST.querystring = 'foo=bar&reqid='
+    REQUEST.querystring = 'foo=bar&ls='
     await exec()
     expect(console.info).toHaveBeenCalledTimes(0)
     expect(console.warn).toHaveBeenCalledTimes(1)
-    expect(getMessage('warn', 0)).toEqual('[WARN] No reqid present: foo=bar&reqid=')
+    expect(getMessage('warn', 0)).toEqual('[WARN] No listener session present: foo=bar&ls=')
     delete REQUEST.querystring
     await exec()
     expect(console.info).toHaveBeenCalledTimes(0)
     expect(console.warn).toHaveBeenCalledTimes(2)
-    expect(getMessage('warn', 1)).toEqual('[WARN] No reqid present: undefined')
+    expect(getMessage('warn', 1)).toEqual('[WARN] No listener session present: undefined')
   })
 
   it('only logs valid content-range', async () => {


### PR DESCRIPTION
We want to key IAB 2 downloads to a "listener session" (`listener-id + url + dateInUtc`).  Instead of the request-uuid.  This allows us to limit listeners to 1 session per day.